### PR TITLE
Add --timeout flag to rest-api to change the default 60 timeout

### DIFF
--- a/netsuite/client.py
+++ b/netsuite/client.py
@@ -147,7 +147,7 @@ class NetSuite:
         cache: zeep.cache.Base = None,
         session: requests.Session = None,
         sandbox: bool = None,
-        args: argparse.Namespace = None
+        args: argparse.Namespace = argparse.Namespace(timeout=60)
     ) -> None:
 
         if sandbox is not None:

--- a/netsuite/client.py
+++ b/netsuite/client.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import re
 import warnings
@@ -6,6 +7,7 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, Callable, Dict, List, Sequence, Union
 from urllib.parse import urlparse
+from operator import attrgetter
 
 import requests
 import zeep
@@ -145,6 +147,7 @@ class NetSuite:
         cache: zeep.cache.Base = None,
         session: requests.Session = None,
         sandbox: bool = None,
+        args: argparse.Namespace = None
     ) -> None:
 
         if sandbox is not None:
@@ -163,6 +166,7 @@ class NetSuite:
         self.__wsdl_url = wsdl_url
         self.__cache = cache
         self.__session = session
+        self.__args = args
 
     @cached_property
     def restlet(self):
@@ -177,6 +181,7 @@ class NetSuite:
                 consumer_secret=self.config.consumer_secret,
                 token_id=self.config.token_id,
                 token_secret=self.config.token_secret,
+                default_timeout=self.args.timeout
             )
         else:
             raise RuntimeError("Rest API is currently only implemented with token auth")
@@ -204,6 +209,10 @@ class NetSuite:
     @property
     def config(self) -> Config:
         return self.__config
+
+    @property
+    def args(self) -> argparse.Namespace:
+        return self.__args
 
     @cached_property
     def hostname(self) -> str:

--- a/netsuite/rest_api.py
+++ b/netsuite/rest_api.py
@@ -48,7 +48,7 @@ class NetSuiteRestApi:
         consumer_secret: str,
         token_id: str,
         token_secret: str,
-        default_timeout: str = 60,
+        default_timeout: int,
         concurrent_requests: int = 10,
     ):
         if not self.has_required_dependencies():


### PR DESCRIPTION
Now users can override the default 60 second timeout in rest-api commands.

Some requests I was running failed with http timeout from Netsuite. This way I can add longer timeout if necessary

For example:
```bash
$ pip uninstall netsuite
$ pip install git+https://github.com/onnimonni/netsuite

# Ensure that you have ~/.config/netsuite.ini

# Make a request that will fail with current 60 seconds
$ time netsuite rest-api --timeout 1200 get /record/v1/metadata-catalog/ > whole-catalog.json
```