### PR TITLE
Accept Python 3.6.12

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -979,7 +979,7 @@ soap_api = ["zeep"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
+python-versions = ">= 3.6.12"
 content-hash = "ab34c13feff970232114042008a9fe490d7b63d4ab1e00d817f885e738c47b84"
 
 [metadata.files]


### PR DESCRIPTION
The latest version of the lib is working for me with Python 3.6.12, but I had to install it manually because pip refused to do so.
This is more to start a debate on what the minimum requirement can (and should) be.