### PR TITLE
Add ability to include additional headers in a search request

### DIFF
--- a/netsuite/soap_api/client.py
+++ b/netsuite/soap_api/client.py
@@ -328,7 +328,9 @@ class NetSuiteSoapApi:
     def SupplyChainTypes(self) -> zeep.client.Factory:
         return self._type_factory("types.supplychain", "lists")
 
-    async def request(self, service_name: str, *args, additionalHeaders: Optional[dict] = None, **kw):
+    async def request(
+        self, service_name: str, *args, additionalHeaders: Optional[dict] = None, **kw
+    ):
         """
         Make a web service request to NetSuite
 
@@ -462,7 +464,9 @@ class NetSuiteSoapApi:
         additionalHeaders: Optional[dict] = None
     ) -> List[zeep.xsd.CompoundValue]:
         """Search records"""
-        return await self.request("search", searchRecord=record, additionalHeaders=additionalHeaders)
+        return await self.request(
+            "search", searchRecord=record, additionalHeaders=additionalHeaders
+        )
 
     @WebServiceCall(
         "body.writeResponseList",

--- a/netsuite/soap_api/client.py
+++ b/netsuite/soap_api/client.py
@@ -328,7 +328,7 @@ class NetSuiteSoapApi:
     def SupplyChainTypes(self) -> zeep.client.Factory:
         return self._type_factory("types.supplychain", "lists")
 
-    async def request(self, service_name: str, *args, additionalHeaders: dict = None, **kw):
+    async def request(self, service_name: str, *args, additionalHeaders: Optional[dict] = None, **kw):
         """
         Make a web service request to NetSuite
 
@@ -459,7 +459,7 @@ class NetSuiteSoapApi:
     )
     async def search(
         self, record: zeep.xsd.CompoundValue,
-        additionalHeaders: dict = None
+        additionalHeaders: Optional[dict] = None
     ) -> List[zeep.xsd.CompoundValue]:
         """Search records"""
         return await self.request("search", searchRecord=record, additionalHeaders=additionalHeaders)

--- a/netsuite/soap_api/client.py
+++ b/netsuite/soap_api/client.py
@@ -328,7 +328,7 @@ class NetSuiteSoapApi:
     def SupplyChainTypes(self) -> zeep.client.Factory:
         return self._type_factory("types.supplychain", "lists")
 
-    async def request(self, service_name: str, *args, **kw):
+    async def request(self, service_name: str, *args, additionalHeaders: dict = None, **kw):
         """
         Make a web service request to NetSuite
 
@@ -339,7 +339,10 @@ class NetSuiteSoapApi:
             The response from NetSuite
         """
         svc = getattr(self.service, service_name)
-        return await svc(*args, _soapheaders=self.generate_passport(), **kw)
+        headers = self.generate_passport()
+        if additionalHeaders:
+            headers.update(additionalHeaders)
+        return await svc(*args, _soapheaders=headers, **kw)
 
     @WebServiceCall(
         "body.readResponseList.readResponse",
@@ -455,10 +458,11 @@ class NetSuiteSoapApi:
         extract=lambda resp: resp["recordList"]["record"],
     )
     async def search(
-        self, record: zeep.xsd.CompoundValue
+        self, record: zeep.xsd.CompoundValue,
+        additionalHeaders: dict = None
     ) -> List[zeep.xsd.CompoundValue]:
         """Search records"""
-        return await self.request("search", searchRecord=record)
+        return await self.request("search", searchRecord=record, additionalHeaders=additionalHeaders)
 
     @WebServiceCall(
         "body.writeResponseList",

--- a/netsuite/soap_api/client.py
+++ b/netsuite/soap_api/client.py
@@ -460,8 +460,7 @@ class NetSuiteSoapApi:
         extract=lambda resp: resp["recordList"]["record"],
     )
     async def search(
-        self, record: zeep.xsd.CompoundValue,
-        additionalHeaders: Optional[dict] = None
+        self, record: zeep.xsd.CompoundValue, additionalHeaders: Optional[dict] = None
     ) -> List[zeep.xsd.CompoundValue]:
         """Search records"""
         return await self.request(


### PR DESCRIPTION
This allows me to add headers such as `{'searchPreferences': {'bodyFieldsOnly': False}}` so that I can get a more detailed response back from the Search action.

My use case was getting the list of values back from a CustomList object. The only way to do that is to include those headers.